### PR TITLE
feat: add Dockerfile for containerized usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY modbus_cli/ modbus_cli/
+
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["modbus"]


### PR DESCRIPTION
## Summary

- Adds a `Dockerfile` using `python:3.12-slim` as the base image
- Single-stage build — installs the package via pip and sets `modbus` as the entrypoint
- Allows using the tool without Python/pip installed locally

## Usage

```bash
docker build -t modbus-cli .
docker run --rm modbus-cli read 192.168.1.10 40001 -c 10
docker run --rm modbus-cli scan 192.168.1.10
docker run --rm modbus-cli dump 192.168.1.10 40001 40100 --json
```

Closes #3