### PR TITLE
Add Docker image support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.venv
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.swo
+*.egg-info/
+dist/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["modbus"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ pip install modbus-cli
 
 Requires Python 3.8+. No binary dependencies. Works on Linux, macOS, and Windows.
 
+### Docker
+
+```bash
+# Build local image
+docker build -t 19bk/modbus-cli .
+
+# Run a command inside the container
+docker run --rm 19bk/modbus-cli read 192.168.1.10 40001 -c 10
+```
+
 ## Commands
 
 ### `modbus read` -- Read registers


### PR DESCRIPTION
## Summary
- add a single-stage Dockerfile using python:3.12-slim
- add a .dockerignore to keep image builds lean
- document docker build/run usage in README

Closes #3